### PR TITLE
Perf: remove hot div and break dependency

### DIFF
--- a/src/mdgx/Peptide.c
+++ b/src/mdgx/Peptide.c
@@ -2313,8 +2313,9 @@ static void GmsSlowStepEnergyAndForces(gpuMultiSim *gms, slmem sta,
             if (gms->igb != 6) {
               rb2 = atmrad * sta.reff[katm];
               efac = exp(-r2 / ((float)4.0 * rb2));
-              fgbi = (float)1.0 / sqrt(r2 + rb2 * efac);
-              fgbk = -gms->kappa * KSCALE / fgbi;
+              temp1 = sqrt(r2 + rb2 * efac);
+              fgbi = (float)1.0 / temp1;
+              fgbk = -gms->kappa * KSCALE * temp1;
               expmkf = exp(fgbk) / gms->dielectric;
               dielfac = (float)1.0 - expmkf;
               usolv += -qq * dielfac * fgbi;

--- a/src/mdgx/kDynamics.h
+++ b/src/mdgx/kDynamics.h
@@ -756,8 +756,9 @@
               int   oatom = __shfl_sync(0xffffffff, loadatm, crdSrcLane, 32);
               float rb2 = treff * oreff;
               float efac = exp(-r2 / ((float)4.0 * rb2));
-              float fgbi = (float)1.0 / sqrt(r2 + rb2 * efac);
-              float fgbk = -cGms.kappa * cGms.kscale / fgbi;
+              float temp1 = sqrt(r2 + rb2 * efac);
+              float fgbi = (float)1.0 / temp1;
+              float fgbk = -cGms.kappa * cGms.kscale * temp1;
               float expmkf = exp(fgbk) / cGms.dielectric;
               float dielfac = (float)1.0 - expmkf;
 #  ifdef COMPUTE_ENERGY

--- a/src/sff/eff.c
+++ b/src/sff/eff.c
@@ -1963,8 +1963,9 @@ REAL_T egb(INT_T * lpears, INT_T * upears, INT_T ** pearlist,
             rj = reff[j];
             rb2 = ri * rj;
             efac = exp(-r2 / (4.0 * rb2));
-            fgbi = 1.0 / sqrt(r2 + rb2 * efac);
-            fgbk = -(*kappa) * KSCALE / fgbi;
+            temp1 = sqrt(r2 + rb2 * efac);
+            fgbi = 1.0 / temp1;
+            fgbk = -(*kappa) * KSCALE * temp1;
 
             expmkf = exp(fgbk) / (*diel_ext);
             dielfac = 1.0 - expmkf;

--- a/src/sff/egbr6.c
+++ b/src/sff/egbr6.c
@@ -447,12 +447,14 @@ REAL_T egbr6(INT_T * lpears, INT_T * upears, INT_T ** pearlist,
             rj = reff[j];
             rb2 = ri * rj;
 #ifdef GRYCUK_FGB
-            fgbi = 1.0 / sqrt(r2 + rb2);
+            temp1 = sqrt(r2 + rb2);
+            fgbi = 1.0 / temp1;
 #else
             efac = exp(-r2 / (4.0 * rb2));
-            fgbi = 1.0 / sqrt(r2 + rb2 * efac);
+            temp1 = sqrt(r2 + rb2 * efac);
+            fgbi = 1.0 / temp1;
 #endif
-            fgbk = -(*kappa) * KSCALE / fgbi;
+            fgbk = -(*kappa) * KSCALE * temp1;
 
             expmkf = exp(fgbk) / (*diel_ext);
             dielfac = 1.0 - expmkf;

--- a/src/sff/hcp_gb.c
+++ b/src/sff/hcp_gb.c
@@ -1379,8 +1379,9 @@ void egb_calc_energy_approx(int j, REAL_T * q_hcp, REAL_T * reff_hcp, int hcp, i
                         rj = reff_hcp[j * hcp + k];
                         rb2 = ri * rj;
                         efac = exp(-r2 / (4.0 * rb2));
-                        fgbi = 1.0 / sqrt(r2 + rb2 * efac);
-                        fgbk = -(*kappa) * KSCALE / fgbi;
+                        temp1 = sqrt(r2 + rb2 * efac);
+                        fgbi = 1.0 / temp1;
+                        fgbk = -(*kappa) * KSCALE * temp1;
 
                         expmkf = exp(fgbk) / (*diel_ext);
                         dielfac = 1.0 - expmkf;
@@ -1475,8 +1476,9 @@ void egb_calc_energy_atom(int j, REAL_T * x, REAL_T * reff_hcp, int *iexw, int h
         rj = reff_hcp[j];
         rb2 = ri * rj;
         efac = exp(-r2 / (4.0 * rb2));
-        fgbi = 1.0 / sqrt(r2 + rb2 * efac);
-        fgbk = -(*kappa) * KSCALE / fgbi;
+        temp1 = sqrt(r2 + rb2 * efac);
+        fgbi = 1.0 / temp1;
+        fgbk = -(*kappa) * KSCALE * temp1;
 
         expmkf = exp(fgbk) / (*diel_ext);
         dielfac = 1.0 - expmkf;

--- a/src/sff/sff2.c
+++ b/src/sff/sff2.c
@@ -2973,9 +2973,11 @@ REAL_T egb2(INT_T * lpears, INT_T * upears, INT_T ** pearlist,
     *
     *      efac = exp(Dij^2 / (4 * rb2))
     *
-    *      fgbi = 1 / sqrt(Dij^2 + rb2 * efac)
+    *      temp1 = sqrt(Dij^2 + rb2 * efac)
     *
-    *      fgbk = -kappa * KSCALE / fgbi
+    *      fgbi = 1 / temp1
+    *
+    *      fgbk = -kappa * KSCALE * temp1
     *
     *      expmkf = exp(fgbk) / DIELECTRIC_CONSTANT
     *
@@ -3805,8 +3807,9 @@ REAL_T egb2(INT_T * lpears, INT_T * upears, INT_T ** pearlist,
             rirjinv = riinv * rjinv;
             rb2 = ri * rj;
             efac = exp(-r2 / (4.0 * rb2));
-            fgbi = 1.0 / sqrt(r2 + rb2 * efac);
-            fgbk = -(*kappa) * KSCALE / fgbi;
+            temp1 = sqrt(r2 + rb2 * efac);
+            fgbi = 1.0 / temp1;
+            fgbk = -(*kappa) * KSCALE * temp1;
 
             /*
              * Calculate the "non-diagonal" energy term, i.e., the term that is a
@@ -4383,8 +4386,9 @@ REAL_T egb2(INT_T * lpears, INT_T * upears, INT_T ** pearlist,
             rirjinv = riinv * rjinv;
             rb2 = ri * rj;
             efac = exp(-r2 / (4.0 * rb2));
-            fgbi = 1.0 / sqrt(r2 + rb2 * efac);
-            fgbk = -(*kappa) * KSCALE / fgbi;
+            temp1 = sqrt(r2 + rb2 * efac);
+            fgbi = 1.0 / temp1;
+            fgbk = -(*kappa) * KSCALE * temp1;
 
             /*
              * Calculate the "non-diagonal" energy term, i.e., the term that is a


### PR DESCRIPTION
Turns one divide into a multiply, and breaks a dependency to allow higher instruction throughput. Most modern CPUs will see about 4% performance uplift.

I found all the instances of `fgbi` and applied the same transformation everywhere. 